### PR TITLE
Replace chalk library with ANSI color codes

### DIFF
--- a/app/utils/format.js
+++ b/app/utils/format.js
@@ -1,5 +1,3 @@
-import chalk from 'chalk';
-
 /**
  * Transform full name of train line to abbreviated version.
  * 
@@ -39,7 +37,7 @@ export function transformLine(line) {
  *   Return the transformed error string.
  */
 export function error(msg) {
-  return console.log(chalk`{red.bold ${msg}}`);
+  return `\x1b[1;91m${msg}\x1b[0m`;
 }
 
 /**
@@ -52,7 +50,23 @@ export function error(msg) {
  *   Return the bolded string.
  */
 export function bold(msg) {
-  return chalk`{white.bold ${msg}}`;
+  return `\x1b[97m${msg}\x1b[0m`;
+}
+
+/**
+ * Transforms the passed string into "WMATA Orange" colored text.
+ * 
+ * Pulled the hex code from the WMATA site by inspecting the
+ * different colors on the site.
+ * 
+ * @param {string} msg
+ *   String to transform.
+ * 
+ * @returns {string}
+ *   Return the string in "WMATA Orange".
+ */
+export function wmataOrange(msg) {
+  return `\x1b[1;38;2;237;139;0m${msg}\x1b[0m`;
 }
 
 /**
@@ -68,7 +82,7 @@ export function bold(msg) {
  *   Return the string in "WMATA Blue".
  */
 export function wmataBlue(msg) {
-  return chalk`{bold.hex('#f00b47') ${msg}}`;
+  return `\x1b[1;38;2;0;156;222m${msg}\x1b[0m`;
 }
 
 /**
@@ -84,7 +98,7 @@ export function wmataBlue(msg) {
  *   Return the string in "WMATA Red".
  */
 export function wmataRed(msg) {
-  return chalk`{hex('#66ff66') ${msg}}`;
+  return `\x1b[1;38;2;191;13;62m${msg}\x1b[0m`
 }
 
 /**
@@ -100,14 +114,32 @@ export function wmataRed(msg) {
  *   Return the string in "WMATA Green".
  */
 export function wmataGreen(msg) {
-  return chalk`{hex('#66ff66') ${msg}}`;
+  return `\x1b[1;38;2;0;177;64m${msg}\x1b[0m`
+}
+
+/**
+ * Transforms the passed string into "WMATA Silver" colored text.
+ * 
+ * Pulled the hex code from the WMATA site by inspecting the
+ * different colors on the site.
+ * 
+ * @param {string} msg
+ *   String to transform.
+ * 
+ * @returns {string}
+ *   Return the string in "WMATA Silver".
+ */
+export function wmataSilver(msg) {
+  return `\x1b[1;38;2;145;157;157m${msg}\x1b[0m`
 }
 
 export default {
   transformLine,
   error,
   bold,
+  wmataOrange,
   wmataRed,
   wmataBlue,
-  wmataGreen
+  wmataGreen,
+  wmataSilver
 };

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "test": "node --test ./app"
   },
   "dependencies": {
-    "chalk": "^2.3.0",
     "cli-table3": "^0.5.1",
     "commander": "^2.19.0",
     "inquirer": "^6.2.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -258,7 +258,7 @@ callsites@^3.0.0:
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
 
-chalk@^2.3.0, chalk@^2.4.2:
+chalk@^2.4.2:
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.4.2.tgz#cd42541677a54333cf541a49108c1432b44c9424"
   integrity sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==


### PR DESCRIPTION
* Remove chalk library
* Refactor calls to chalk's color and bold functions with the ANSI equivalent
* Add color helper function for `wmataOrange` and `wmataSilver`

Resolves #22